### PR TITLE
Fix inst commands file issues.

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,9 +438,9 @@ The installer can be reached through the monitor GUI as follows:
   * When inst is done loading media, it will prompt for the next location. Type
   * ```done```
 * From inst, Admin menu
-  * booterizer generates a 'commands' file that contains all of the commands for inst to run
+  * booterizer provides a 'commands' file that contains all of the commands for inst to run
   * ```source booterizer:commands```
-  * NOTE: I've not yet confirmed these work. They appear to, but just in case, they are:
+  * Just in case, sourced commands are:
     ```
     return
     keep *

--- a/ansible/roles/fetch_files/files/commands
+++ b/ansible/roles/fetch_files/files/commands
@@ -5,3 +5,5 @@ keep incompleteoverlays
 remove java_dev*
 remove java2_plugin*
 conflicts
+go
+quit

--- a/ansible/roles/fetch_files/tasks/copy_inst_commands.yml
+++ b/ansible/roles/fetch_files/tasks/copy_inst_commands.yml
@@ -1,5 +1,5 @@
 - name: Copy inst commands file
-  file:
+  copy:
     src: files/commands
     dest: /irix/commands
     owner: vagrant

--- a/ansible/roles/fetch_files/tasks/main.yml
+++ b/ansible/roles/fetch_files/tasks/main.yml
@@ -17,5 +17,7 @@
 - import_tasks: symlink_to_irix.yml
 #--------- Generate selections
 - import_tasks: generate_selections.yml
+#--------- Copy commands file
+- import_tasks: copy_inst_commands.yml
 #--------- Display  useful info
 - import_tasks: display_results.yml


### PR DESCRIPTION
It seems that the copy task for inst commands was missing from main.yml. Also a couple minor other fixes. This way it seemed to work (tested with Indy & 6.5.22).