### PR TITLE
Update selections.j2

### DIFF
--- a/ansible/roles/fetch_files/templates/selections.j2
+++ b/ansible/roles/fetch_files/templates/selections.j2
@@ -1,10 +1,6 @@
 # Overlay
 from {{ hostip }}:{{ irixversion }}/Overlay/disc1/dist
-{% if '6.5.22'  == irixversion %}
-from {{ hostip }}:{{ irixversion }}/Overlay/disc2/CDROM/dist
-{% else %}
 from {{ hostip }}:{{ irixversion }}/Overlay/disc2/dist
-{% endif %}
 from {{ hostip }}:{{ irixversion }}/Overlay/disc3/dist
 # Foundation
 from {{ hostip }}:Foundation/disc1/dist


### PR DESCRIPTION
Patch selections file trying to fetch overlay disc2 dist from wrong path for IRIX 6.5.22.