### PR TITLE
docs: fix requirements filename in setup command

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ cd /root/projects/github/booterizer
 
 ```
 cd ansible
-pip3 install -r requirements.tx
+pip3 install -r requirements.txt
 reboot
 ```
 


### PR DESCRIPTION
## Summary
- update the README setup command to install from `requirements.txt`
- match the existing dependency file in the `ansible` directory

## Validation
- `test -f ansible/requirements.txt`
- `test ! -e ansible/requirements.tx`
- `python3 -m pip install -r requirements.tx` fails because the file is missing
- isolated venv install from `ansible/requirements.txt` succeeds
- `git diff --check`
